### PR TITLE
Static linking

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -28,10 +28,8 @@ jobs:
           - os: ubuntu-latest
             arch: x86_64
 
-          # TODO:
-          # Temporarily disabled, due to loading issue of legacy.dll
-          #- os: windows-latest
-          #  arch: AMD64
+          - os: windows-latest
+            arch: AMD64
 
           - os: macos-13  # Intel
             arch: x86_64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,21 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(vanillapdf.py C CXX)
-
 # Add option to build a pypi package
 option(VANILLAPDF_PY_PACKAGE_BUILD "Enable packaging install mode" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries instead of static ones" OFF)
+
+if (BUILD_SHARED_LIBS)
+    set(VCPKG_LIBRARY_LINKAGE "dynamic")
+else()
+    set(VCPKG_LIBRARY_LINKAGE "static")
+    set(VCPKG_TARGET_TRIPLET "x64-windows-static")
+endif()
 
 # Note: This needs to be included before defining the main project
 # Check for VCPKG - C++ package management system
 include(cmake/vcpkg_init.cmake)
+
+project(vanillapdf.py C CXX)
 
 # Find VanillaPDF via vcpkg
 find_package(vanillapdf CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,21 @@ cmake_minimum_required(VERSION 3.15)
 option(VANILLAPDF_PY_PACKAGE_BUILD "Enable packaging install mode" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static ones" OFF)
 
-if (BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS)
     set(VCPKG_LIBRARY_LINKAGE "dynamic")
 else()
     set(VCPKG_LIBRARY_LINKAGE "static")
-    set(VCPKG_TARGET_TRIPLET "x64-windows-static")
+endif()
+
+# Detect platform and set triplet dynamically only if not predefined
+if(NOT DEFINED VCPKG_TARGET_TRIPLET)
+    if(WIN32)
+        set(VCPKG_TARGET_TRIPLET "x64-windows-${VCPKG_LIBRARY_LINKAGE}")
+    elseif(APPLE)
+        set(VCPKG_TARGET_TRIPLET "x64-osx-${VCPKG_LIBRARY_LINKAGE}")
+    elseif(UNIX)
+        set(VCPKG_TARGET_TRIPLET "x64-linux-${VCPKG_LIBRARY_LINKAGE}")
+    endif()
 endif()
 
 # Note: This needs to be included before defining the main project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,16 +8,10 @@ if(BUILD_SHARED_LIBS)
     set(VCPKG_LIBRARY_LINKAGE "dynamic")
 else()
     set(VCPKG_LIBRARY_LINKAGE "static")
-endif()
 
-# Detect platform and set triplet dynamically only if not predefined
-if(NOT DEFINED VCPKG_TARGET_TRIPLET)
-    if(WIN32)
-        set(VCPKG_TARGET_TRIPLET "x64-windows-${VCPKG_LIBRARY_LINKAGE}")
-    elseif(APPLE)
-        set(VCPKG_TARGET_TRIPLET "x64-osx-${VCPKG_LIBRARY_LINKAGE}")
-    elseif(UNIX)
-        set(VCPKG_TARGET_TRIPLET "x64-linux-${VCPKG_LIBRARY_LINKAGE}")
+    # Windows with static linking requires a different vcpkg triplet
+    if(WIN32 AND NOT DEFINED VCPKG_TARGET_TRIPLET)
+        set(VCPKG_TARGET_TRIPLET "x64-windows-static")
     endif()
 endif()
 
@@ -47,12 +41,15 @@ target_link_libraries(_vanillapdf PRIVATE
     Python3::Module
 )
 
-# Correct cross-platform suffix
-set(VANILLAPDF_PY_TARGET_SUFFIX ".so")
-
-# Specific case on windows it is different
+# Specify target suffix based on the current platform
 if(WIN32)
     set(VANILLAPDF_PY_TARGET_SUFFIX ".pyd")
+elseif(APPLE)
+    set(VANILLAPDF_PY_TARGET_SUFFIX ".so")
+elseif(UNIX)
+    set(VANILLAPDF_PY_TARGET_SUFFIX ".so")
+else()
+    message(FATAL_ERROR "Unknown host platform")
 endif()
 
 # Disable the lib prefix, which is not common for python modules
@@ -68,6 +65,8 @@ message(STATUS "Python extension will be built as: ${CMAKE_CURRENT_BINARY_DIR}/_
 
 if(VANILLAPDF_PY_PACKAGE_BUILD)
 
+    message(STATUS "Packaging mode: ${VCPKG_LIBRARY_LINKAGE}")
+
     # Required to get CMAKE_INSTALL_LIBDIR
     include(GNUInstallDirs)
 
@@ -76,37 +75,40 @@ if(VANILLAPDF_PY_PACKAGE_BUILD)
         RUNTIME DESTINATION vanillapdf  # .dll (Windows)
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}  # .lib/.a — not needed in wheel, but consistent
     )
-    
-    # Copy dependent shared libraries (Linux)
-    if(UNIX AND NOT APPLE)
 
-        # Set RPATH to look in the same folder
-        set_target_properties(_vanillapdf PROPERTIES
-            INSTALL_RPATH "$ORIGIN"
-        )
+    # Only copy shared dependencies if we're linking dynamically
+    if(BUILD_SHARED_LIBS)
 
-        file(GLOB VCPKG_SOS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/*.so*")
-        install(FILES ${VCPKG_SOS} DESTINATION vanillapdf)
+        # Copy dependent shared libraries (Linux)
+        if(UNIX AND NOT APPLE)
+
+            # Set RPATH to look in the same folder
+            set_target_properties(_vanillapdf PROPERTIES
+                INSTALL_RPATH "$ORIGIN"
+            )
+
+            file(GLOB VCPKG_SOS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/*.so*")
+            install(FILES ${VCPKG_SOS} DESTINATION vanillapdf)
+        endif()
+
+        # Copy dylibs (macOS)
+        if(APPLE)
+            set_target_properties(_vanillapdf PROPERTIES
+                INSTALL_RPATH "@loader_path"
+                BUILD_RPATH "@loader_path"
+            )
+
+            file(GLOB VCPKG_DYLIBS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/*.dylib")
+            install(FILES ${VCPKG_DYLIBS} DESTINATION vanillapdf)
+        endif()
+
+        # Copy dlls (Windows)
+        if(WIN32)
+            file(GLOB VCPKG_DLLS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/*.dll")
+            install(FILES ${VCPKG_DLLS} DESTINATION vanillapdf)
+        endif()
+
     endif()
-    
-    # Copy dylibs (macOS)
-    if(APPLE)
-        set_target_properties(_vanillapdf PROPERTIES
-            INSTALL_RPATH "@loader_path"
-            BUILD_RPATH "@loader_path"
-        )
-
-        file(GLOB VCPKG_DYLIBS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/*.dylib")
-        install(FILES ${VCPKG_DYLIBS} DESTINATION vanillapdf)
-    endif()
-    
-    # Copy dlls (Windows)
-    if(WIN32)
-        file(GLOB VCPKG_DLLS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/*.dll")
-        install(FILES ${VCPKG_DLLS} DESTINATION vanillapdf)
-    endif()
-    
-
 
 endif()
 

--- a/vcpkg-ports/vanillapdf/portfile.cmake
+++ b/vcpkg-ports/vanillapdf/portfile.cmake
@@ -10,8 +10,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vanillapdf/vanillapdf
-    REF "static-library"
-    SHA512 78519781d98a4da751d6c4618e0e7d61eff05a3134f2dd229fa3064952fdd320316eb89ee3c7c5d4513320fb43abc39078886d3109077bd6a0740db9a2cb2c8e
+    REF "main"
+    SHA512 74d97603ed160a84430f911fc0bca679754feea63b1ff3b8e89f8f7d96a65eab11794990e692dd23889d7298366ab8200ddb7198cae498ce04d6e55b9b897239
 )
 
 vcpkg_cmake_configure(

--- a/vcpkg-ports/vanillapdf/portfile.cmake
+++ b/vcpkg-ports/vanillapdf/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vanillapdf/vanillapdf
     REF "static-library"
-    SHA512 75be0c6c79b3147ea0ae63d15e85486a23fe1f3b5d3efeb25667aec75c3267c74e33671f1dc9bc73270e38c0233ae25806d74c71076a471335c59230d4e108bf
+    SHA512 78519781d98a4da751d6c4618e0e7d61eff05a3134f2dd229fa3064952fdd320316eb89ee3c7c5d4513320fb43abc39078886d3109077bd6a0740db9a2cb2c8e
 )
 
 vcpkg_cmake_configure(

--- a/vcpkg-ports/vanillapdf/portfile.cmake
+++ b/vcpkg-ports/vanillapdf/portfile.cmake
@@ -1,10 +1,17 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+# Vanilla.PDF vcpkg portfile
+# https://github.com/vanillapdf/vanillapdf
+#
+# Maintainer: Juraj Zikmund <jzikmund@vanillapdf.com>
+# License: Apache-2.0
+#
+# This portfile builds Vanilla.PDF, a cross-platform SDK for creating and modifying PDF documents.
+# It supports both static and shared builds via the standard CMake `BUILD_SHARED_LIBS` option.
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vanillapdf/vanillapdf
-    REF "main"
-    SHA512 fd49a8020381f8a9a1adb7fb90a03309637680669c81ecc09e5a38b264521029c19da8c4d1e298bb8efd485eb9c28b15fd398dc135efe7920d04c126cd0f0f38
+    REF "static-library"
+    SHA512 75be0c6c79b3147ea0ae63d15e85486a23fe1f3b5d3efeb25667aec75c3267c74e33671f1dc9bc73270e38c0233ae25806d74c71076a471335c59230d4e108bf
 )
 
 vcpkg_cmake_configure(


### PR DESCRIPTION
Add support for selecting static/dynamic linking of vanillapdf and other dependencies.
In order to create a portable version of python wrapper it seems most straightforward to link the dependencies statically and create only one .pyd/.so/.dylib.
This is the python module interface, that would not need to resolve any other runtime dependencies.
Shipping dependencies either windows or linux/mac is causing a lot of issues.
