### PR TITLE
Dynamic CRT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
 
     # Windows with static linking requires a different vcpkg triplet
     if(WIN32 AND NOT DEFINED VCPKG_TARGET_TRIPLET)
-        set(VCPKG_TARGET_TRIPLET "x64-windows-static")
+        set(VCPKG_TARGET_TRIPLET "x64-windows-static-md")
     endif()
 endif()
 

--- a/vcpkg-ports/vanillapdf/portfile.cmake
+++ b/vcpkg-ports/vanillapdf/portfile.cmake
@@ -10,8 +10,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vanillapdf/vanillapdf
-    REF "main"
-    SHA512 74d97603ed160a84430f911fc0bca679754feea63b1ff3b8e89f8f7d96a65eab11794990e692dd23889d7298366ab8200ddb7198cae498ce04d6e55b9b897239
+    REF "static-crt"
+    SHA512 f945060042fba5100fc6cbce25932c468146cb1fba7590f0f509a1cb8d94955cd096b2c6fc9d919bc1b5dfce6b967445bebe6409502f2aaf37bc5cca93732ece
 )
 
 vcpkg_cmake_configure(

--- a/vcpkg-ports/vanillapdf/portfile.cmake
+++ b/vcpkg-ports/vanillapdf/portfile.cmake
@@ -10,8 +10,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vanillapdf/vanillapdf
-    REF "static-crt"
-    SHA512 f945060042fba5100fc6cbce25932c468146cb1fba7590f0f509a1cb8d94955cd096b2c6fc9d919bc1b5dfce6b967445bebe6409502f2aaf37bc5cca93732ece
+    REF "main"
+    SHA512 00e111dd9d69bbc03786baf826cd4ebc87d50025731af12671408108ef0988b9ecbebae54d169169f9dcfae1efcd1466d0a0dc5e563af0fc6d389f1d5365a78f
 )
 
 vcpkg_cmake_configure(


### PR DESCRIPTION
Add support for static/dynamic CRT linking.
For PyPI packaging it is recommended to use dynamic CRT linking, from what I have read.
We will need to double-check how to ensure that the target machine does have proper CRL installed.
