### PR TITLE
Add Buffer bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(_vanillapdf MODULE
 
     src/vanillapdf_native/documentmodule.c
     src/vanillapdf_native/documentmodule.h
+    src/vanillapdf_native/buffermodule.c
+    src/vanillapdf_native/buffermodule.h
 )
 
 target_link_libraries(_vanillapdf PRIVATE

--- a/src/vanillapdf/__init__.py
+++ b/src/vanillapdf/__init__.py
@@ -1,8 +1,10 @@
 from .document import Document
+from .buffer import Buffer
 
 try:
     from ._version import version as __version__
 except ImportError:
     __version__ = "0.0.0.dev"
 
-__all__ = ["Document", "__version__"]
+__all__ = ["Document", "Buffer", "__version__"]
+

--- a/src/vanillapdf/buffer.py
+++ b/src/vanillapdf/buffer.py
@@ -1,0 +1,40 @@
+from . import _vanillapdf
+
+class Buffer:
+    def __init__(self, handle) -> None:
+        if handle is None:
+            raise RuntimeError("Failed to create buffer")
+        self._handle = handle
+
+    @staticmethod
+    def create() -> "Buffer":
+        """Create an empty buffer."""
+        handle = _vanillapdf.create()
+        return Buffer(handle)
+
+    @staticmethod
+    def create_from_data(data: bytes) -> "Buffer":
+        """Create a buffer from the provided bytes."""
+        handle = _vanillapdf.create_from_data(data)
+        return Buffer(handle)
+
+    def set_data(self, data: bytes) -> None:
+        _vanillapdf.set_data(self._handle, data)
+
+    def get_data(self) -> bytes:
+        return _vanillapdf.get_data(self._handle)
+
+    def close(self):
+        if self._handle is not None:
+            _vanillapdf.release(self._handle)
+            self._handle = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def __del__(self):
+        self.close()
+

--- a/src/vanillapdf_native/buffermodule.c
+++ b/src/vanillapdf_native/buffermodule.c
@@ -1,0 +1,99 @@
+#define PY_SSIZE_T_CLEAN
+
+#include <Python.h>
+
+#include <vanillapdf/c_values.h>
+#include <vanillapdf/utils/c_buffer.h>
+
+#include "buffermodule.h"
+
+PyObject* vp_buffer_create(PyObject* self, PyObject* args) {
+    BufferHandle* handle = NULL;
+    error_type err = Buffer_Create(&handle);
+
+    if (err != VANILLAPDF_ERROR_SUCCESS || handle == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to create buffer");
+        return NULL;
+    }
+
+    return PyCapsule_New((void*)handle, "VanillaPDF.Buffer", NULL);
+}
+
+PyObject* vp_buffer_create_from_data(PyObject* self, PyObject* args) {
+    const char* data;
+    Py_ssize_t size;
+    if (!PyArg_ParseTuple(args, "y#", &data, &size)) {
+        return NULL;
+    }
+
+    BufferHandle* handle = NULL;
+    error_type err = Buffer_CreateFromData((string_type)data, (size_type)size, &handle);
+
+    if (err != VANILLAPDF_ERROR_SUCCESS || handle == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to create buffer from data");
+        return NULL;
+    }
+
+    return PyCapsule_New((void*)handle, "VanillaPDF.Buffer", NULL);
+}
+
+PyObject* vp_buffer_set_data(PyObject* self, PyObject* args) {
+    PyObject* capsule;
+    const char* data;
+    Py_ssize_t size;
+    if (!PyArg_ParseTuple(args, "Oy#", &capsule, &data, &size)) {
+        return NULL;
+    }
+
+    BufferHandle* handle = (BufferHandle*)PyCapsule_GetPointer(capsule, "VanillaPDF.Buffer");
+    if (!handle) {
+        return NULL;
+    }
+
+    error_type err = Buffer_SetData(handle, (string_type)data, (size_type)size);
+    if (err != VANILLAPDF_ERROR_SUCCESS) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to set buffer data");
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+
+PyObject* vp_buffer_get_data(PyObject* self, PyObject* args) {
+    PyObject* capsule;
+    if (!PyArg_ParseTuple(args, "O", &capsule)) {
+        return NULL;
+    }
+
+    BufferHandle* handle = (BufferHandle*)PyCapsule_GetPointer(capsule, "VanillaPDF.Buffer");
+    if (!handle) {
+        return NULL;
+    }
+
+    string_type data = NULL;
+    size_type size = 0;
+    error_type err = Buffer_GetData(handle, &data, &size);
+    if (err != VANILLAPDF_ERROR_SUCCESS) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to get buffer data");
+        return NULL;
+    }
+
+    return PyBytes_FromStringAndSize((const char*)data, (Py_ssize_t)size);
+}
+
+PyObject* vp_buffer_release(PyObject* self, PyObject* args) {
+    PyObject* capsule;
+    if (!PyArg_ParseTuple(args, "O", &capsule)) {
+        return NULL;
+    }
+
+    BufferHandle* handle = (BufferHandle*)PyCapsule_GetPointer(capsule, "VanillaPDF.Buffer");
+    if (!handle) {
+        return NULL;
+    }
+
+    Buffer_Release(handle);
+    Py_RETURN_NONE;
+}
+
+

--- a/src/vanillapdf_native/buffermodule.h
+++ b/src/vanillapdf_native/buffermodule.h
@@ -1,0 +1,12 @@
+#ifndef BUFFERMODULE_H
+#define BUFFERMODULE_H
+
+#include <Python.h>
+
+PyObject* vp_buffer_create(PyObject* self, PyObject* args);
+PyObject* vp_buffer_create_from_data(PyObject* self, PyObject* args);
+PyObject* vp_buffer_set_data(PyObject* self, PyObject* args);
+PyObject* vp_buffer_get_data(PyObject* self, PyObject* args);
+PyObject* vp_buffer_release(PyObject* self, PyObject* args);
+
+#endif // BUFFERMODULE_H

--- a/src/vanillapdf_native/vanillapdfmodule.c
+++ b/src/vanillapdf_native/vanillapdfmodule.c
@@ -3,11 +3,17 @@
 #include <Python.h>
 
 #include "documentmodule.h"
+#include "buffermodule.h"
 
 static PyMethodDef VanillapdfMethods[] = {
     {"document_open", vp_document_open, METH_VARARGS, "Open a Document"},
     {"document_save",   vp_document_save,   METH_VARARGS, "Save a Document"},
-    {"document_release",vp_document_release,METH_VARARGS, "Release a Document"},
+    {"document_release", vp_document_release, METH_VARARGS, "Release a Document"},
+    {"create", vp_buffer_create, METH_NOARGS, "Create a Buffer"},
+    {"create_from_data", vp_buffer_create_from_data, METH_VARARGS, "Create a Buffer from bytes"},
+    {"set_data", vp_buffer_set_data, METH_VARARGS, "Set Buffer contents"},
+    {"get_data", vp_buffer_get_data, METH_VARARGS, "Get Buffer contents"},
+    {"release", vp_buffer_release, METH_VARARGS, "Release a Buffer"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,0 +1,21 @@
+import vanillapdf
+
+
+def test_buffer_roundtrip():
+    data = b"hello world"
+    buf = vanillapdf.Buffer.create_from_data(data)
+    out = buf.get_data()
+    assert out == data
+    buf.close()
+
+
+def test_empty_create_and_set_data():
+    buf = vanillapdf.Buffer.create()
+    buf.set_data(b"foo")
+    out = buf.get_data()
+    assert out == b"foo"
+    buf.close()
+
+test_buffer_roundtrip()
+test_empty_create_and_set_data()
+


### PR DESCRIPTION
## Summary
- implement Buffer bindings for VanillaPDF
- expose Buffer class in Python package
- include new buffer module sources in build
- test Buffer roundtrip
- refine Buffer wrapper API to use static constructors
- add Buffer.set_data and rename bindings per native API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68640b5db718832b87f67788bfdf31af