### PR TITLE
Add Python 3.14 support, drop EOL versions, update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install build tools
         run: |
@@ -76,7 +76,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_BUILD_VERBOSITY: 1
           CIBW_SKIP: "cp*-musllinux_*"
           CIBW_ARCHS_WINDOWS: "${{ matrix.arch }}"

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install build tools
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "vanillapdf"
 dynamic = ["version"]
 description = "Python bindings for VanillaPDF — a C++ PDF processing library"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 
 authors = [
@@ -23,12 +23,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent"
 ]
 
@@ -39,7 +38,7 @@ Documentation = "https://vanillapdf.github.io/vanillapdf"
 Issues = "https://github.com/vanillapdf/vanillapdf/issues"
 
 [build-system]
-requires = ["scikit-build-core>=0.7.0", "setuptools>=61", "setuptools-scm>=8.1"]
+requires = ["scikit-build-core>=0.10", "setuptools>=80", "setuptools-scm>=9"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
## Summary

**Python:**
- Add Python 3.14 support
- Drop Python 3.8 and 3.9 (both reached end-of-life)
- Update `requires-python` to `>=3.10`
- CI workflows now use Python 3.14

**Build dependencies:**
- scikit-build-core: `>=0.7.0` → `>=0.10`
- setuptools: `>=61` → `>=80`
- setuptools-scm: `>=8.1` → `>=9`

## Test plan

- [x] CI passes on all platforms
- [x] Wheels build for Python 3.10-3.14

🤖 Generated with [Claude Code](https://claude.ai/code)