### PR TITLE
Fix memory management in C extension using handle box pattern

### DIFF
--- a/src/vanillapdf/buffer.py
+++ b/src/vanillapdf/buffer.py
@@ -9,24 +9,24 @@ class Buffer:
     @staticmethod
     def create() -> "Buffer":
         """Create an empty buffer."""
-        handle = _vanillapdf.create()
+        handle = _vanillapdf.buffer_create()
         return Buffer(handle)
 
     @staticmethod
     def create_from_data(data: bytes) -> "Buffer":
         """Create a buffer from the provided bytes."""
-        handle = _vanillapdf.create_from_data(data)
+        handle = _vanillapdf.buffer_create_from_data(data)
         return Buffer(handle)
 
     def set_data(self, data: bytes) -> None:
-        _vanillapdf.set_data(self._handle, data)
+        _vanillapdf.buffer_set_data(self._handle, data)
 
     def get_data(self) -> bytes:
-        return _vanillapdf.get_data(self._handle)
+        return _vanillapdf.buffer_get_data(self._handle)
 
     def close(self):
         if self._handle is not None:
-            _vanillapdf.release(self._handle)
+            _vanillapdf.buffer_release(self._handle)
             self._handle = None
 
     def __enter__(self):

--- a/src/vanillapdf_native/buffermodule.h
+++ b/src/vanillapdf_native/buffermodule.h
@@ -3,10 +3,10 @@
 
 #include <Python.h>
 
-PyObject* vp_buffer_create(PyObject* self, PyObject* args);
-PyObject* vp_buffer_create_from_data(PyObject* self, PyObject* args);
-PyObject* vp_buffer_set_data(PyObject* self, PyObject* args);
-PyObject* vp_buffer_get_data(PyObject* self, PyObject* args);
-PyObject* vp_buffer_release(PyObject* self, PyObject* args);
+PyObject* buffer_create(PyObject* self, PyObject* args);
+PyObject* buffer_create_from_data(PyObject* self, PyObject* args);
+PyObject* buffer_set_data(PyObject* self, PyObject* args);
+PyObject* buffer_get_data(PyObject* self, PyObject* args);
+PyObject* buffer_release(PyObject* self, PyObject* args);
 
 #endif // BUFFERMODULE_H

--- a/src/vanillapdf_native/documentmodule.h
+++ b/src/vanillapdf_native/documentmodule.h
@@ -3,8 +3,8 @@
 
 #include <Python.h>
 
-PyObject* vp_document_open(PyObject* self, PyObject* args);
-PyObject* vp_document_save(PyObject* self, PyObject* args);
-PyObject* vp_document_release(PyObject* self, PyObject* args);
+PyObject* document_open(PyObject* self, PyObject* args);
+PyObject* document_save(PyObject* self, PyObject* args);
+PyObject* document_release(PyObject* self, PyObject* args);
 
 #endif // DOCUMENTMODULE_H

--- a/src/vanillapdf_native/vanillapdfmodule.c
+++ b/src/vanillapdf_native/vanillapdfmodule.c
@@ -6,14 +6,14 @@
 #include "buffermodule.h"
 
 static PyMethodDef VanillapdfMethods[] = {
-    {"document_open", vp_document_open, METH_VARARGS, "Open a Document"},
-    {"document_save",   vp_document_save,   METH_VARARGS, "Save a Document"},
-    {"document_release", vp_document_release, METH_VARARGS, "Release a Document"},
-    {"create", vp_buffer_create, METH_NOARGS, "Create a Buffer"},
-    {"create_from_data", vp_buffer_create_from_data, METH_VARARGS, "Create a Buffer from bytes"},
-    {"set_data", vp_buffer_set_data, METH_VARARGS, "Set Buffer contents"},
-    {"get_data", vp_buffer_get_data, METH_VARARGS, "Get Buffer contents"},
-    {"release", vp_buffer_release, METH_VARARGS, "Release a Buffer"},
+    {"document_open", document_open, METH_VARARGS, "Open a Document"},
+    {"document_save", document_save, METH_VARARGS, "Save a Document"},
+    {"document_release", document_release, METH_VARARGS, "Release a Document"},
+    {"buffer_create", buffer_create, METH_NOARGS, "Create a Buffer"},
+    {"buffer_create_from_data", buffer_create_from_data, METH_VARARGS, "Create a Buffer from bytes"},
+    {"buffer_set_data", buffer_set_data, METH_VARARGS, "Set Buffer contents"},
+    {"buffer_get_data", buffer_get_data, METH_VARARGS, "Get Buffer contents"},
+    {"buffer_release", buffer_release, METH_VARARGS, "Release a Buffer"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -3,18 +3,17 @@ import vanillapdf
 
 def test_buffer_roundtrip():
     data = b"hello world"
-    buf = vanillapdf.Buffer.create_from_data(data)
-    out = buf.get_data()
-    assert out == data
-    buf.close()
+    with vanillapdf.Buffer.create_from_data(data) as buf:
+        out = buf.get_data()
+        assert out == data
 
 
 def test_empty_create_and_set_data():
-    buf = vanillapdf.Buffer.create()
-    buf.set_data(b"foo")
-    out = buf.get_data()
-    assert out == b"foo"
-    buf.close()
+    with vanillapdf.Buffer.create() as buf:
+        buf.set_data(b"foo")
+        out = buf.get_data()
+        assert out == b"foo"
+
 
 test_buffer_roundtrip()
 test_empty_create_and_set_data()

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3,19 +3,17 @@ import vanillapdf
 
 def test_open_save_release():
     base = Path(__file__).parent
-    
+
     test_input = base.parent / "assets" / "pdf-test.pdf"
     test_output = base / "test_output.pdf"
 
     assert test_input.exists(), f"{test_input} not found"
 
-    doc = vanillapdf.Document(str(test_input))
-    assert doc is not None
+    with vanillapdf.Document(str(test_input)) as doc:
+        assert doc is not None
+        doc.save(str(test_output))
+        assert test_output.exists()
 
-    doc.save(str(test_output))
-    assert test_output.exists()
-
-    doc.close()
     test_output.unlink()
 
 test_open_save_release()


### PR DESCRIPTION
## Summary

- Introduces `DocumentHandleBox` / `BufferHandleBox` structs for safe handle lifecycle management
- Capsule destructor properly frees both native handle and box
- Handles cleanup correctly when `PyCapsule_New` or `PyMem_Malloc` fails
- Validates capsules with `PyCapsule_IsValid` before use
- Returns `TypeError` for invalid handles, `ValueError` for released handles
- Makes `release()` idempotent (safe to call multiple times)
- Updates tests to use context manager (`with`) pattern
- Removes `vp_` prefix from function names for cleaner API

## Test plan

- [x] Run `pytest tests/` to verify document and buffer operations work
- [x] Verify context manager properly releases resources
- [x] Test calling `close()` multiple times doesn't crash
- [x] Build on all platforms (Ubuntu, Windows, macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)