### PR TITLE
Update vanillapdf to 2.3.0-alpha.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ project(vanillapdf.py C CXX)
 include(FetchContent)
 FetchContent_Declare(vanillapdf
     GIT_REPOSITORY https://github.com/vanillapdf/vanillapdf.git
-    GIT_TAG        v2.2.0
+    GIT_TAG        v2.3.0-alpha.1
     GIT_SUBMODULES ""  # Don't fetch submodules (we have our own vcpkg)
 )
 


### PR DESCRIPTION
Updated the Vanilla.PDF FetchContent dependency tag in CMakeLists.txt from v2.2.0 to v2.3.0-alpha.1 to match the new release you mentioned.

Committed the change as chore: bump vanillapdf to v2.3.0-alpha.1 (50ca0ec) and created a PR record with the same title/body via the make_pr tool.

Testing
✅ git status --short
✅ git diff -- CMakeLists.txt