### PR TITLE
Update vanillapdf to v2.3.0-beta.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/" # pyproject.toml
+    schedule:
+      interval: "weekly"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,6 @@ python -m build --wheel
 ```bash
 python -m venv venv
 venv\Scripts\activate
-pip install -r requirements.txt
 pip install -e .
 ```
 
@@ -71,18 +70,17 @@ C++ handles are wrapped as PyCapsule objects for safe passing between Python and
 ### Build System
 
 - **CMake** with **scikit-build-core** for Python packaging
-- **vcpkg** (in `external/vcpkg/`) manages C++ dependencies
-- Custom vcpkg port in `vcpkg-ports/vanillapdf/`
+- **vcpkg** manages C++ dependencies, fetched via CMake `FetchContent` (no submodule)
+- The vanillapdf C++ library itself is also fetched via `FetchContent` (pinned tag in `CMakeLists.txt`)
 - Static linking by default; dynamic linking available via `BUILD_SHARED_LIBS`
 
 ### Key Files
 
 | File | Purpose |
 |------|---------|
-| `CMakeLists.txt` | Build configuration, defines `_vanillapdf` module |
+| `CMakeLists.txt` | Build configuration, defines `_vanillapdf` module, pins vcpkg + vanillapdf versions |
 | `pyproject.toml` | Python packaging, scikit-build-core config |
-| `cmake/vcpkg_init.cmake` | Auto-bootstraps vcpkg if missing |
-| `vcpkg.json` | Declares vanillapdf C++ dependency |
+| `vcpkg.json` | Declares the C++ dependencies this project needs from vcpkg |
 
 ## Testing
 
@@ -97,4 +95,4 @@ pytest tests/ -v                 # Verbose output
 ## CI/CD
 
 - **sanity-check.yml** - Runs on push/PR to main; builds and tests on Ubuntu, Windows, macOS
-- **release.yml** - Manual dispatch; builds wheels for Python 3.8-3.13 and publishes to PyPI
+- **release.yml** - Manual dispatch; builds wheels for Python 3.10-3.14 and publishes to PyPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ project(vanillapdf.py C CXX)
 include(FetchContent)
 FetchContent_Declare(vanillapdf
     GIT_REPOSITORY https://github.com/vanillapdf/vanillapdf.git
-    GIT_TAG        v2.2.0
+    GIT_TAG        v2.3.0-beta.1
     GIT_SUBMODULES ""  # Don't fetch submodules (we have our own vcpkg)
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-scikit-build-core>=0.4
-build

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "dependencies": [
         "spdlog",
-        "nlohmann-json",
+        "fmt",
         "openssl",
         "libjpeg-turbo",
         "openjpeg",


### PR DESCRIPTION
## Summary
- Bump the vanillapdf FetchContent tag from `v2.2.0` to `v2.3.0-beta.1` (supersedes the stale `v2.3.0-alpha.1` bump in #30, closed).
- Fix `vcpkg.json` to match what the library actually requires: drop `nlohmann-json` (only needed when upstream's `VANILLAPDF_ENABLE_LICENSING` is enabled, which we never set) and add `fmt` (now an unconditional `find_package(fmt CONFIG REQUIRED)` upstream).
- Add a `pip` ecosystem entry to `.github/dependabot.yml` so Python build dependencies get tracked (previously only `github-actions` was watched).
- Remove the unused, out-of-sync `requirements.txt` (pinned `scikit-build-core>=0.4` vs. the actual `pyproject.toml` requirement of `>=0.10`; not referenced by CI or packaging).
- Fix stale `CLAUDE.md` references to `external/vcpkg/`, `vcpkg-ports/vanillapdf/`, and `cmake/vcpkg_init.cmake` (all removed during the earlier vcpkg submodule → FetchContent migration) and correct the documented Python wheel range (3.8-3.13 → 3.10-3.14).

## Test plan
- [x] Clean rebuild against `v2.3.0-beta.1` with the trimmed `vcpkg.json` (`pip install -e ".[test]"`)
- [x] `pytest tests/` — 16/16 passed
- [x] `vanillapdf.LibraryInfo.get_version()` reports `2.3.0.0`
- [x] Repeated after removing `requirements.txt` to confirm no build/test regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)