### PR TITLE
Keep the C++ SDK tree out of the wheel (#46)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,10 +175,17 @@ message(STATUS "Python extension will be built as: ${CMAKE_CURRENT_BINARY_DIR}/_
 if(VANILLAPDF_PY_PACKAGE_BUILD)
     include(GNUInstallDirs)
 
+    # Install only the Python extension under a dedicated component. The upstream
+    # vanillapdf FetchContent registers its own install() rules (headers, cmake
+    # package, share, vanillapdf.tools) under the "Development"/"Runtime"
+    # components; scikit-build-core is told to install only "python_extension"
+    # (see [tool.scikit-build] install.components), so none of that C++ SDK tree
+    # lands in the wheel. The library is statically linked into the extension, so
+    # the .so/.pyd is self-contained.
     install(TARGETS _vanillapdf
-        LIBRARY DESTINATION vanillapdf  # .so (Unix)
-        RUNTIME DESTINATION vanillapdf  # .dll (Windows)
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION vanillapdf COMPONENT python_extension  # .so (Unix)
+        RUNTIME DESTINATION vanillapdf COMPONENT python_extension  # .pyd (Windows)
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT python_extension
     )
 
     # Set RPATH for Unix platforms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
 build-dir = "build"
+# Install only our extension's component into the wheel. The upstream vanillapdf
+# library (fetched via CMake) registers install() rules for its headers, cmake
+# package, share files, and the vanillapdf.tools executable; restricting to the
+# "python_extension" component keeps that C++ SDK tree out of the wheel.
+install.components = ["python_extension"]
 
 [tool.scikit-build.metadata]
 version.provider = "scikit_build_core.metadata.setuptools_scm"


### PR DESCRIPTION
Closes #46.

The wheel bundled the entire upstream **vanillapdf C++ SDK install tree** — `include/vanillapdf/*.h`, `lib/cmake/vanillapdf/*`, `share/vanillapdf/*`, and `bin/vanillapdf.tools.exe` — because `FetchContent_MakeAvailable(vanillapdf)` registers those `install()` rules (tagged `Development`/`Runtime`) into our build, and `cmake --install` installed all of them.

## Fix
- Tag our extension's install with a dedicated CMake component:
  `install(TARGETS _vanillapdf ... COMPONENT python_extension)`.
- Restrict scikit-build-core to it: `[tool.scikit-build] install.components = ["python_extension"]`.

Only the statically-linked `_vanillapdf` module is installed; the upstream SDK components are skipped. The pure-Python package (wrappers, `py.typed`, `_vanillapdf.pyi`) is copied by scikit-build-core's separate package mechanism and is unaffected.

## Verified
- **Wheel contents** now: only `vanillapdf/` + `*.dist-info/` — no `include/`, `lib/`, `share/`, `bin/`. Matches the issue's acceptance criterion.
- Package essentials intact: `_vanillapdf.pyd`, `_vanillapdf.pyi`, `py.typed`, and all sub-packages.
- **Installs + runs**: fresh venv → `import vanillapdf`, `IntegerObject.create(42).value == 42`.
- **CI parity**: a fresh `pip install -e .` still builds and imports; `pytest` 113 passed, `ruff` clean, `pyright` strict 0.

## Note
The `vanillapdf.tools.exe` is still *built* (upstream default) but no longer *installed* into the wheel. Suppressing the build itself would need an upstream toggle; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)