### PR TITLE
Test built wheels before publish; add Linux aarch64 (#49)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -27,6 +27,9 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x86_64
+
+          - os: ubuntu-24.04-arm  # native ARM64 runner (no QEMU emulation)
+            arch: aarch64
 
           - os: windows-latest
             arch: AMD64
@@ -40,6 +43,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # setuptools-scm needs tags to derive the release version
 
       - name: Cache vcpkg binaries
         uses: actions/cache@v6
@@ -64,10 +69,19 @@ jobs:
         env:
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_BUILD_VERBOSITY: 1
+          # musllinux (Alpine) is intentionally not built: the vendored C++ deps
+          # do not build cleanly against musl. Supported: manylinux glibc x86_64
+          # and aarch64.
           CIBW_SKIP: "cp*-musllinux_*"
           CIBW_ARCHS_WINDOWS: "${{ matrix.arch }}"
           CIBW_ARCHS_MACOS: "${{ matrix.arch }}"
           CIBW_ARCHS_LINUX: "${{ matrix.arch }}"
+          # Install the built wheel into a fresh env and run the suite against it,
+          # so a wheel that compiles but is broken at runtime (missing symbol,
+          # bad ABI, unshipped file) can never be published. Tests import the
+          # installed package; assets resolve from {project}/assets via conftest.
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_ENVIRONMENT_LINUX: "VCPKG_BINARY_SOURCES=clear;files,/project/.vcpkg-cache,readwrite"
           CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=11.0 VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite"
           CIBW_ENVIRONMENT_WINDOWS: "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite"
@@ -81,6 +95,12 @@ jobs:
         with:
           name: vanillapdf-wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: dist
+
+  # No sdist is published: building from source bootstraps vcpkg and FetchContents
+  # the C++ library from git at install time (toolchain + network required), so an
+  # sdist would only ever be used on unsupported platforms -- where a long build
+  # would likely fail anyway, a worse experience than pip's clean "no matching
+  # distribution". Source builds remain available via `pip install git+<repo>`.
 
   publish:
     name: Publish to Python Package Index


### PR DESCRIPTION
Closes #49 (scoped: wheel-testing + ARM64; sdist deliberately dropped — see below).

The release pipeline built wheels but never **tested** them, so a wheel that compiles yet is broken at runtime could be published. This adds the missing runtime gate and broadens coverage.

## Changes
- **Test every wheel before publish.** `CIBW_TEST_REQUIRES=pytest` + `CIBW_TEST_COMMAND=pytest {project}/tests` — cibuildwheel installs each built wheel into a fresh env and runs the full suite against it. Catches ABI/packaging regressions (missing symbol, bad ABI, unshipped file) that a build-only pipeline misses. Tests import the installed package; assets resolve from `{project}/assets` via conftest.
- **Native Linux aarch64.** Added `ubuntu-24.04-arm` / `aarch64` to the matrix (native ARM runner — no slow QEMU emulation). ARM64 Linux users (Graviton, Pi) can now `pip install`.
- **Correct versioning.** `fetch-depth: 0` so setuptools-scm sees tags.

## Decisions (documented in the workflow + #49)
- **No sdist.** Source builds bootstrap vcpkg and `FetchContent` the C++ library from git *at install time* (toolchain + network required). An sdist would only ever be hit on an unsupported platform, where the heavy build would likely fail — a worse experience than pip's clean "no matching distribution". Source builds stay available via `pip install git+<repo>`.
- **musllinux unsupported.** The vendored C++ deps don't build cleanly on musl; kept the existing skip, now with a comment. Supported: manylinux glibc x86_64 + aarch64, Windows AMD64, macOS Intel + Apple Silicon, CPython 3.10–3.14.

## Note
This is a workflow change — it can't be fully exercised without running the release (which publishes). The YAML is validated and the cibuildwheel keys are standard; the first `testpypi` dispatch will confirm the test step end-to-end. Worth a **TestPyPI** run before the first real `pypi` publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)