### PR TITLE
Fix release pipeline: cibuildwheel env, PyPI version scheme, bump vanillapdf to v2.3.0-rc.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,11 @@ jobs:
           # installed package; assets resolve from {project}/assets via conftest.
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
-          CIBW_ENVIRONMENT_LINUX: "VCPKG_BINARY_SOURCES=clear;files,/project/.vcpkg-cache,readwrite"
-          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=11.0 VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite"
-          CIBW_ENVIRONMENT_WINDOWS: "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite"
+          # Single-quote the value: cibuildwheel parses CIBW_ENVIRONMENT shell-style,
+          # so the ';' in VCPKG_BINARY_SOURCES must be quoted or it's "malformed".
+          CIBW_ENVIRONMENT_LINUX: "VCPKG_BINARY_SOURCES='clear;files,/project/.vcpkg-cache,readwrite'"
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=11.0 VCPKG_BINARY_SOURCES='clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite'"
+          CIBW_ENVIRONMENT_WINDOWS: "VCPKG_BINARY_SOURCES='clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite'"
           CIBW_BEFORE_ALL_MACOS: |
             brew install ninja
           CIBW_BEFORE_ALL_LINUX: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ project(vanillapdf.py C CXX)
 # Fetch VanillaPDF library
 # VANILLAPDF_GIT_TAG can be overridden (e.g. -DVANILLAPDF_GIT_TAG=main) to build
 # against the upstream library's development branch, as bleeding-edge.yml does
-set(VANILLAPDF_GIT_TAG "v2.3.0-beta.1" CACHE STRING "vanillapdf git tag, branch, or commit to fetch")
+set(VANILLAPDF_GIT_TAG "v2.3.0-rc.1" CACHE STRING "vanillapdf git tag, branch, or commit to fetch")
 
 include(FetchContent)
 FetchContent_Declare(vanillapdf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,9 @@ version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
 version_scheme = "guess-next-dev"
-local_scheme = "node-and-date"
+# No local version segment (+g<hash>): PyPI rejects PEP 440 local identifiers,
+# so keep versions publishable. Dev builds still carry .devN off the last tag.
+local_scheme = "no-local-version"
 version_file = "src/vanillapdf/_version.py"
 
 [tool.scikit-build.cmake]


### PR DESCRIPTION
Release-pipeline fixes uncovered by the TestPyPI dry-run, plus the native dep bump that gets this branch's CI green.

## 1. Malformed cibuildwheel `CIBW_ENVIRONMENT`
The TestPyPI dry-run failed on **all 5 platforms** at cibuildwheel startup:

```
cibuildwheel: Malformed environment option 'VCPKG_BINARY_SOURCES=clear;files,.../.vcpkg-cache,readwrite'
```

cibuildwheel parses `CIBW_ENVIRONMENT` shell-style, so the `;` in `VCPKG_BINARY_SOURCES=clear;files,...` is a metachar and the whole option is rejected — no wheels build. Pre-existing (predates the #51 test-step changes). **Fix:** single-quote the value in all three `CIBW_ENVIRONMENT_{LINUX,MACOS,WINDOWS}`.

## 2. PyPI-unpublishable version scheme
The dry-run's publish step then rejected `0.0.2.dev38+g02c444c00` — the PEP 440 local version identifier (`+g<hash>`) is forbidden by (Test)PyPI. **Fix:** switch setuptools-scm `local_scheme` to `no-local-version` so dev builds keep `.devN` but drop the local segment.

## 3. Concurrent `Document.create` race → bump vanillapdf to `v2.3.0-rc.1`
With the pipeline unblocked, `sanity-check.yml` went red on **macOS** with `tests/test_threading.py::test_parallel_create_save_reopen`:

```
Document_Create: VANILLAPDF_ERROR_PARAMETER_VALUE (Trying to create new
document for file doc_N_0.pdf, but the file instance was already opened)
```

Root cause is in the **native library**, not the bindings. Its global document registry (`SemanticUtils`, keyed by raw `syntax::File*`) guarded the *create* path (`Document::CreateFile` → `HasMappedDocument`) on mere key-presence, while the *open* path (`GetOrCreateDocument`) also checked `IsActive()`. Concurrent Document create/open/destroy racing on that shared map produced the false "already opened". It surfaced once #40 released the GIL around blocking native calls (letting these lifecycle calls truly overlap); the native thread-safety test only ever stressed concurrent `OpenFile`, never concurrent `Create`. macOS-specific because that allocator recycles freed `File` addresses aggressively — never reproduced on Windows at 16 threads × 40 iters.

Fixed upstream and released as `v2.3.0-rc.1`; **fix:** bump the pinned `VANILLAPDF_GIT_TAG` (was `v2.3.0-beta.1`).

## Validation
Local (Windows, on rc.1): full suite **116 passed**, threading module hammered **30× clean**, `ruff`/`pyright` clean, native stub in sync. The macOS race can only be proven gone in CI — this PR's `sanity-check.yml` run is that signal.

A follow-up PR will re-pin `v2.3.0-rc.1 → v2.3.0` once the official tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
