### PR TITLE
Group Dependabot updates for github-actions and Sphinx docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,20 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      # Roll all GitHub Actions bumps into a single PR
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/" # pyproject.toml
     schedule:
       interval: "weekly"
+    groups:
+      # Roll the Sphinx docs toolchain (docs/requirements.txt) into one PR
+      sphinx:
+        patterns:
+          - "sphinx"
+          - "sphinx-*"
+          - "sphinxext-*"


### PR DESCRIPTION
Groups Dependabot PRs to cut down on churn, mirroring the grouping approach in the native `vanillapdf` repo.

## Changes
- **github-actions**: all action bumps roll into a single weekly PR (`"*"` pattern).
- **pip / sphinx**: the Sphinx docs toolchain (`docs/requirements.txt` — `sphinx`, `sphinx-rtd-theme`, `sphinx-copybutton`, `sphinxext-opengraph`) groups into one PR instead of four separate ones.

## Follow-up after merge
The four currently-open Sphinx PRs (#57-60) will be superseded by a single grouped PR on Dependabot's next run (it auto-closes the old ones). Comment `@dependabot recreate` on one of them to trigger it immediately rather than waiting for the weekly schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)