### PR TITLE
Bump vanillapdf to v2.3.0-rc.2 and adopt mirrored versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,37 @@
 # Changelog
 
 All notable changes to this project are documented here. The format is based on
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
-follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for its public
-API (the names exported from the top-level `vanillapdf` package) once it reaches
-`1.0.0`. While in `0.x`, minor versions may include breaking changes.
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Versioning
+
+These bindings **mirror the version of the underlying
+[Vanilla.PDF](https://github.com/vanillapdf/vanillapdf) C++ library they wrap**,
+matching the convention used by
+[vanillapdf.net](https://github.com/vanillapdf/vanillapdf.net). Version `2.3.0`
+of this package wraps version `2.3.0` of the native library, so the two are
+always readable together. The pinned native tag lives in `CMakeLists.txt`
+(`VANILLAPDF_GIT_TAG`).
+
+Binding-only changes — a fix in the Python or extension layer with no
+corresponding native release — get a fourth component: `2.3.0.1`, `2.3.0.2`, and
+so on. This is a normal PEP 440 release segment and sorts as expected. Note that
+PEP 440 post-releases (`2.3.0.post1`) are deliberately *not* used, as the spec
+reserves those for metadata corrections rather than bug fixes.
 
 ## [Unreleased]
 
-The bindings grew from a thin wrapper into a broadly usable, typed, thread-safe
-PDF library. Highlights since `0.0.1`:
+## [2.3.0-rc.2]
+
+First release under the mirrored versioning scheme described above; the jump
+from `0.0.1` reflects the change in scheme, not a sudden change in the code. The
+bindings grew from a thin wrapper into a broadly usable, typed, thread-safe PDF
+library. Highlights since `0.0.1`:
+
+### Native library
+- Wraps Vanilla.PDF `v2.3.0-rc.2` (previously pinned to `v2.3.0-rc.1`), which
+  carries the fix for the object-registry race that made concurrent
+  `Document.create` calls flaky.
 
 ### Added
 - **Syntax object model** — `Object` plus every concrete type (`Null`, `Boolean`,
@@ -59,5 +81,6 @@ PDF library. Highlights since `0.0.1`:
 - Initial release: a thin wrapper exposing `Document` (open/save), `Buffer`,
   `File`, `LibraryInfo`, and `Logging`.
 
-[Unreleased]: https://github.com/vanillapdf/vanillapdf.py/compare/v0.0.1...HEAD
+[Unreleased]: https://github.com/vanillapdf/vanillapdf.py/compare/v2.3.0-rc.2...HEAD
+[2.3.0-rc.2]: https://github.com/vanillapdf/vanillapdf.py/compare/v0.0.1...v2.3.0-rc.2
 [0.0.1]: https://github.com/vanillapdf/vanillapdf.py/releases/tag/v0.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ project(vanillapdf.py C CXX)
 # Fetch VanillaPDF library
 # VANILLAPDF_GIT_TAG can be overridden (e.g. -DVANILLAPDF_GIT_TAG=main) to build
 # against the upstream library's development branch, as bleeding-edge.yml does
-set(VANILLAPDF_GIT_TAG "v2.3.0-rc.1" CACHE STRING "vanillapdf git tag, branch, or commit to fetch")
+set(VANILLAPDF_GIT_TAG "v2.3.0-rc.2" CACHE STRING "vanillapdf git tag, branch, or commit to fetch")
 
 include(FetchContent)
 FetchContent_Declare(vanillapdf


### PR DESCRIPTION
Pins the native library to `v2.3.0-rc.2` (released 2026-07-18) and documents the versioning scheme this package follows.

## Native bump

`CMakeLists.txt` moves from `v2.3.0-rc.1` to `v2.3.0-rc.2`. rc.1 is the pin that fixed the object-registry race behind flaky concurrent `Document.create` calls, so this bump needs a clean run of `test_threading.py` and the sanitizer workflow before merge — that is the main risk here, not the one-line diff.

## Versioning

These bindings now mirror the version of the C++ library they wrap, matching the convention already used by [vanillapdf.net](https://github.com/vanillapdf/vanillapdf.net) (`v2.3.0-rc.1`, `v2.2.1`, `v2.2.0`, ... tracking the native tags one for one). Package `2.3.0` wraps native `2.3.0`.

The jump from `0.0.1` reflects this change in scheme, not a sudden change in the code.

The previous CHANGELOG header promised SemVer-once-`1.0.0` with breaking changes allowed in `0.x`, which no longer describes how the package is versioned, so it is replaced with an explicit `Versioning` section.

### Binding-only fixes

A fix in the Python or extension layer with no corresponding native release gets a fourth component — `2.3.0.1`, `2.3.0.2`. PEP 440 post-releases (`2.3.0.post1`) are deliberately not used, as the spec reserves those for metadata corrections rather than bug fixes.

Ordering was verified with `packaging`:

```
0.0.0 < 0.0.2.dev39 < 2.3.0rc2 < 2.3.0 < 2.3.0.1 < 2.3.0.2 < 2.3.1
```

`2.3.0.1` is not treated as a prerelease and matches `~=2.3.0`, and sorts below the next native patch.

## Verification

setuptools-scm derives `2.3.0rc2` from a `v2.3.0-rc.2` tag on a clean tree (checked locally with a throwaway tag, since removed — this PR creates no tag).

Not verified locally: that the extension actually builds and tests green against rc.2. That is left to CI, which builds the full matrix.

## Follow-up

Release machinery is intentionally not in this PR. A follow-up ports the native repo's model: `CONTRIBUTING.md`, `RELEASE-GUIDE.md`, `lint-pr-title.yml`, `github-release.yml`, and a `release.yml` rework so the workflow owns tag creation (build and test untagged via `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VANILLAPDF`, draft release, `production` gate, tag on approval).

Unrelated note surfaced while investigating: the `0.0.0` release on TestPyPI dates from 2025-05-17 and predates `fetch-depth: 0` being added to the release checkout in #51. It is a fossil, already superseded by `0.0.2.dev39`, and needs no action.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>