### PR TITLE
ci: adopt native release model with draft-gated tagging

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,163 @@
+name: Create GitHub Release
+
+# Creates the GitHub release as a DRAFT and attaches the built wheels. The tag is
+# deliberately NOT created here: publishing the draft (after the production gate
+# in release.yml) is what creates it, at `target`. Pre-creating the tag would
+# leave the published release bound to an untagged-* placeholder.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      prerelease:
+        required: true
+        type: boolean
+      latest:
+        required: false
+        type: boolean
+        default: true
+      target:
+        description: "Commit SHA the tag is created at when the draft is published"
+        required: false
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag name (e.g. v2.3.0-rc.2)"
+        required: true
+      prerelease:
+        description: "Set to true for prerelease"
+        required: true
+        type: boolean
+      latest:
+        description: "Set as latest release"
+        required: false
+        type: boolean
+        default: true
+      target:
+        description: "Commit SHA the tag is created at when the draft is published"
+        required: false
+        type: string
+        default: ''
+
+permissions: {}
+
+jobs:
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write       # Required to create a release and upload assets
+      id-token: write       # Required for Sigstore keyless signing
+      attestations: write   # Required for GitHub artifact attestations
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Create draft release
+        env:
+          TAG: ${{ inputs.tag }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          LATEST: ${{ inputs.latest }}
+          TARGET: ${{ inputs.target }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Creating draft release for tag: $TAG"
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists. Skipping."
+            exit 0
+          fi
+
+          LATEST_FLAG=""
+          if [ "$LATEST" = "false" ]; then
+            LATEST_FLAG="--latest=false"
+          fi
+
+          # The tag must NOT exist yet: publishing this draft is what creates the
+          # tag (at TARGET) and binds the release to it.
+          TARGET_FLAG=""
+          if [ -n "$TARGET" ]; then
+            TARGET_FLAG="--target $TARGET"
+          fi
+
+          PRERELEASE_FLAG=""
+          if [ "$PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "$TAG" \
+            --title "vanillapdf.py $TAG" \
+            --generate-notes \
+            --draft \
+            $PRERELEASE_FLAG \
+            $TARGET_FLAG \
+            $LATEST_FLAG
+
+      - name: Download built wheels
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: vanillapdf-wheels-*
+          merge-multiple: true
+
+      - name: Upload wheels to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          shopt -s nullglob
+          WHEELS=(dist/*.whl)
+          if [ ${#WHEELS[@]} -eq 0 ]; then
+            echo "::error::No wheels found to attach to the release"
+            exit 1
+          fi
+          echo "Uploading ${#WHEELS[@]} wheels"
+          gh release upload "$TAG" "${WHEELS[@]}"
+
+      - name: Attest wheel provenance
+        id: attest-wheels
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/*.whl
+
+      - name: Upload provenance to release
+        # Attach the signed provenance bundle as a release asset. The attestation
+        # also lives in GitHub's attestation store, but OpenSSF Scorecard's
+        # Signed-Releases check only inspects release assets and credits a
+        # *.intoto.jsonl provenance file.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUNDLE_PATH: ${{ steps.attest-wheels.outputs.bundle-path }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          PROVENANCE="vanillapdf.py-${TAG}.intoto.jsonl"
+          cp "$BUNDLE_PATH" "$PROVENANCE"
+          gh release upload "$TAG" "$PROVENANCE"
+
+      - name: Generate SBOM
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/dependency-graph/sbom" \
+            | jq '.sbom' > "vanillapdf.py-${TAG}-sbom.spdx.json"
+
+      - name: Upload SBOM to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          gh release upload "$TAG" "vanillapdf.py-${TAG}-sbom.spdx.json"
+
+      - name: Attest SBOM
+        uses: actions/attest@v4
+        with:
+          subject-path: vanillapdf.py-${{ inputs.tag }}-sbom.spdx.json
+          sbom-path: vanillapdf.py-${{ inputs.tag }}-sbom.spdx.json

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,28 @@
+name: Lint PR title
+
+# This repository squash-merges pull requests, so the PR TITLE becomes the
+# commit subject that lands on the target branch. Validate it against the
+# Conventional Commits spec, matching the native vanillapdf repository.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: ["main", "release/*"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Validate against Conventional Commits
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,153 @@
 name: Build and Publish
 
+# Release model (mirrors the native vanillapdf repository):
+#
+#   dispatch (tag + dry_run) -> prepare -> verify -> build wheels
+#     dry_run:true  -> dry-run report, nothing published, no tag created
+#     dry_run:false -> TestPyPI (staging) -> draft GitHub release -> production
+#                      gate -> publish draft (THIS creates the tag) -> PyPI
+#
+# Tags are never created by hand. The tag does not exist while the wheels are
+# built and tested, so a failed build can simply be re-run without having to
+# delete a dangling tag. setuptools-scm is fed the version through
+# SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VANILLAPDF instead of reading it from a tag.
+#
+# NOTE: PyPI Trusted Publishing is bound to (repository, workflow filename,
+# environment name). Do not rename this file or the `pypi` / `testpypi`
+# environments without updating the publisher configuration on PyPI first.
+
 on:
   workflow_dispatch:
     inputs:
-      publish_target:
-        description: "Select target pypi environment"
+      tag:
+        description: "Tag name to create (e.g. v2.3.0-rc.2)"
         required: true
-        default: "testpypi"
-        type: choice
-        options:
-          - testpypi
-          - pypi
+        type: string
+      dry_run:
+        description: "Dry run - build and validate without publishing or tagging"
+        required: false
+        type: boolean
+        default: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
+  prepare:
+    name: Prepare release metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.parse.outputs.tag }}
+      version: ${{ steps.parse.outputs.version }}
+      prerelease: ${{ steps.parse.outputs.prerelease }}
+      is_latest: ${{ steps.parse.outputs.is_latest }}
+      dry_run: ${{ steps.parse.outputs.dry_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Parse tag
+        id: parse
+        env:
+          TAG: ${{ inputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet packaging
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+
+          # Normalise the tag into the PEP 440 version setuptools-scm would have
+          # derived from it (v2.3.0-rc.2 -> 2.3.0rc2), and classify it.
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os, subprocess
+          from packaging.version import Version, InvalidVersion
+
+          tag = os.environ["TAG"]
+          if not tag.startswith("v"):
+              raise SystemExit(f"::error::Tag must start with 'v': {tag}")
+          try:
+              version = Version(tag[1:])
+          except InvalidVersion as exc:
+              raise SystemExit(f"::error::Tag is not a valid PEP 440 version: {exc}")
+
+          print(f"version={version}")
+          print(f"prerelease={str(version.is_prerelease).lower()}")
+
+          # "latest" drives the GitHub release flag. A prerelease is never latest;
+          # a stable release is latest only if it outranks every existing tag.
+          if version.is_prerelease:
+              print("is_latest=false")
+          else:
+              out = subprocess.run(["git", "tag", "-l", "v*"],
+                                   capture_output=True, text=True, check=True).stdout
+              existing = []
+              for line in out.split():
+                  try:
+                      existing.append(Version(line[1:]))
+                  except InvalidVersion:
+                      continue
+              highest = max(existing, default=None)
+              print(f"is_latest={str(highest is None or version >= highest).lower()}")
+          PY
+
+      - name: Summary
+        run: |
+          echo "Tag:        ${{ steps.parse.outputs.tag }}"
+          echo "Version:    ${{ steps.parse.outputs.version }}"
+          echo "Prerelease: ${{ steps.parse.outputs.prerelease }}"
+          echo "Latest:     ${{ steps.parse.outputs.is_latest }}"
+          echo "Dry run:    ${{ steps.parse.outputs.dry_run }}"
+
+  verify:
+    name: Verify release preconditions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Tag must not already exist
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Publishing the draft release is what creates the tag. If it already
+          # exists the release would bind to an untagged-* placeholder instead.
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG already exists. Pick a new version."
+            exit 1
+          fi
+          echo "Tag $TAG is free."
+
+      - name: CHANGELOG must document this version
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          SECTION="## [${TAG#v}]"
+          if ! grep -qF "$SECTION" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '$SECTION' section."
+            exit 1
+          fi
+          echo "Found $SECTION in CHANGELOG.md."
+
   build-wheels:
     name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }})
+    needs: [prepare, verify]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -44,7 +173,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0  # setuptools-scm needs tags to derive the release version
+          fetch-depth: 0  # setuptools-scm inspects git even when a version is pretended
 
       - name: Cache vcpkg binaries
         uses: actions/cache@v6
@@ -82,15 +211,52 @@ jobs:
           # installed package; assets resolve from {project}/assets via conftest.
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
+          # The tag does not exist yet (it is created when the draft release is
+          # published), so setuptools-scm cannot derive the version from git.
+          # Feed it the version explicitly instead; without this every wheel
+          # would be stamped with a guessed .devN version.
+          #
           # Single-quote the value: cibuildwheel parses CIBW_ENVIRONMENT shell-style,
           # so the ';' in VCPKG_BINARY_SOURCES must be quoted or it's "malformed".
-          CIBW_ENVIRONMENT_LINUX: "VCPKG_BINARY_SOURCES='clear;files,/project/.vcpkg-cache,readwrite'"
-          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=11.0 VCPKG_BINARY_SOURCES='clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite'"
-          CIBW_ENVIRONMENT_WINDOWS: "VCPKG_BINARY_SOURCES='clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite'"
+          CIBW_ENVIRONMENT_LINUX: >-
+            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VANILLAPDF=${{ needs.prepare.outputs.version }}
+            VCPKG_BINARY_SOURCES='clear;files,/project/.vcpkg-cache,readwrite'
+          CIBW_ENVIRONMENT_MACOS: >-
+            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VANILLAPDF=${{ needs.prepare.outputs.version }}
+            MACOSX_DEPLOYMENT_TARGET=11.0
+            VCPKG_BINARY_SOURCES='clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite'
+          CIBW_ENVIRONMENT_WINDOWS: >-
+            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VANILLAPDF=${{ needs.prepare.outputs.version }}
+            VCPKG_BINARY_SOURCES='clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite'
           CIBW_BEFORE_ALL_MACOS: |
             brew install ninja
           CIBW_BEFORE_ALL_LINUX: |
             yum install -y zip unzip gcc gcc-c++ make tar curl perl perl-IPC-Cmd ninja-build
+
+      - name: Verify wheel versions match the tag
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          # A wheel stamped with anything else means the pretend-version did not
+          # reach the build; publishing it would burn the wrong version on PyPI.
+          shopt -s nullglob
+          FOUND=0
+          for whl in dist/*.whl; do
+            FOUND=1
+            name="$(basename "$whl")"
+            got="$(echo "$name" | cut -d- -f2)"
+            if [ "$got" != "$VERSION" ]; then
+              echo "::error::$name is version '$got', expected '$VERSION'"
+              exit 1
+            fi
+          done
+          if [ "$FOUND" -eq 0 ]; then
+            echo "::error::No wheels were produced"
+            exit 1
+          fi
+          echo "All wheels are version $VERSION."
 
       - name: Upload built wheels
         uses: actions/upload-artifact@v7
@@ -104,17 +270,42 @@ jobs:
   # would likely fail anyway, a worse experience than pip's clean "no matching
   # distribution". Source builds remain available via `pip install git+<repo>`.
 
-  publish:
-    name: Publish to Python Package Index
-    needs: build-wheels
+  dry-run-report:
+    name: Dry run summary
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
+    needs: [prepare, build-wheels]
+    if: always() && needs.prepare.outputs.dry_run == 'true'
+    steps:
+      - name: Report
+        run: |
+          echo "=== Dry Run Summary ==="
+          echo "Tag:        ${{ needs.prepare.outputs.tag }}"
+          echo "Version:    ${{ needs.prepare.outputs.version }}"
+          echo "Prerelease: ${{ needs.prepare.outputs.prerelease }}"
+          echo "Latest:     ${{ needs.prepare.outputs.is_latest }}"
+          echo ""
+          echo "Wheel build: ${{ needs.build-wheels.result }}"
+          echo ""
+          if [ "${{ needs.build-wheels.result }}" != "success" ]; then
+            echo "::error::Dry-run validation failed"
+            exit 1
+          fi
+          echo "Nothing was published and no tag was created."
+          echo "=== All dry-run validations passed ==="
+
+  testpypi:
+    name: Publish to TestPyPI (staging)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [prepare, build-wheels]
+    if: needs.prepare.outputs.dry_run == 'false'
     environment:
-      name: ${{ github.event.inputs.publish_target }}
+      name: testpypi
       url: ${{ vars.PYPI_PROJECT_URL }}
-
     permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-
+      id-token: write  # Mandatory for trusted publishing
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -122,7 +313,98 @@ jobs:
           pattern: vanillapdf-wheels-*
           merge-multiple: true
 
-      - name: Publish to ${{ github.event.inputs.publish_target }} (Trusted Publisher)
+      - name: Publish to TestPyPI (Trusted Publisher)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
+          print-hash: true
+          verbose: true
+          # Staging is re-runnable: a re-dispatch of the same version must not
+          # fail on files TestPyPI already has.
+          skip-existing: true
+
+  create-draft-release:
+    name: Create draft release
+    needs: [prepare, testpypi]
+    if: needs.prepare.outputs.dry_run == 'false'
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/github-release.yml
+    with:
+      tag: ${{ needs.prepare.outputs.tag }}
+      prerelease: ${{ fromJSON(needs.prepare.outputs.prerelease) }}
+      latest: ${{ fromJSON(needs.prepare.outputs.is_latest) }}
+      target: ${{ github.sha }}
+    secrets: inherit
+
+  production-gate:
+    name: Production gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 4320  # allow a long human review window
+    permissions: {}
+    needs: [prepare, create-draft-release]
+    environment: production
+    outputs:
+      tag: ${{ needs.prepare.outputs.tag }}
+      is_latest: ${{ needs.prepare.outputs.is_latest }}
+      prerelease: ${{ needs.prepare.outputs.prerelease }}
+    steps:
+      - run: |
+          echo "Draft release ${{ needs.prepare.outputs.tag }} created, wheels attached,"
+          echo "and staged on TestPyPI."
+          echo "Review and edit the release body in the UI, then approve to publish."
+
+  publish-release:
+    name: Publish release (creates the tag)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    needs: production-gate
+    outputs:
+      tag: ${{ needs.production-gate.outputs.tag }}
+      is_latest: ${{ needs.production-gate.outputs.is_latest }}
+      prerelease: ${{ needs.production-gate.outputs.prerelease }}
+    steps:
+      - name: Publish draft release
+        # Flipping the draft to published is what creates the tag, at the
+        # draft's target commit. BOT_TOKEN is preferred so the tag can be
+        # created under any tag protection rulesets; GITHUB_TOKEN is the
+        # fallback when no bot token is configured.
+        env:
+          TAG: ${{ needs.production-gate.outputs.tag }}
+          IS_LATEST: ${{ needs.production-gate.outputs.is_latest }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LATEST_FLAG=""
+          if [ "$IS_LATEST" = "false" ]; then
+            LATEST_FLAG="--latest=false"
+          fi
+          gh release edit "$TAG" --draft=false $LATEST_FLAG
+          echo "Published $TAG; the tag now exists."
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: publish-release
+    environment:
+      name: pypi
+      url: ${{ vars.PYPI_PROJECT_URL }}
+    permissions:
+      id-token: write  # Mandatory for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: vanillapdf-wheels-*
+          merge-multiple: true
+
+      - name: Publish to PyPI (Trusted Publisher)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: ${{ vars.PYPI_REPOSITORY_URL }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to Vanilla.PDF Python Bindings
+
+Thank you for considering contributing to the **Vanilla.PDF Python bindings**!
+This repository packages the [Vanilla.PDF](https://github.com/vanillapdf/vanillapdf)
+C++17 library as a Python extension; it follows the same contribution conventions
+as the native repository.
+
+---
+
+## 🐞 Reporting Bugs
+
+Report bugs on [GitHub Issues](https://github.com/vanillapdf/vanillapdf.py/issues).
+Please include:
+
+- Version of `vanillapdf` (`python -c "import vanillapdf; print(vanillapdf.__version__)"`)
+- Python version, operating system, and architecture
+- Whether you installed a published wheel or built from source
+- A clear description of what happens and what you expected instead
+- A minimal code snippet that reproduces it
+- A sample PDF (anonymized if needed)
+
+If the bug is in PDF parsing or writing rather than in the Python layer, it may
+belong in the [native repository](https://github.com/vanillapdf/vanillapdf/issues)
+instead — report it here either way and we will move it if needed.
+
+Still unsure? Reach out to [info@vanillapdf.com](mailto:info@vanillapdf.com).
+
+---
+
+## 💡 Feedback & Feature Requests
+
+Missing a key feature? Have a great idea? We'd love to hear it — send a note to
+[jzikmund@vanillapdf.com](mailto:jzikmund@vanillapdf.com).
+
+---
+
+## 🔁 Submitting Pull Requests
+
+**🚨 MANDATORY: Branch and PR workflow**
+
+- **All changes must go through a branch and pull request** — this is required by
+  repository permissions.
+- **Never commit directly to `main` or `release/*`** — they are protected.
+- Create a new branch for every change, no matter how small.
+- Follow the naming convention: **`feature/description`** or **`fix/description`**.
+
+### 🌳 Branch naming
+
+| Prefix              | Use for                                                       |
+| ------------------- | ------------------------------------------------------------- |
+| `feature/…`         | New functionality                                             |
+| `fix/…`             | Bug fixes, dependency bumps, and other corrections            |
+| `release/x.y`       | **Reserved** — long-lived maintenance lines, never a change    |
+
+`release/x.y` branches exist to maintain an already-released line (for example
+`release/2.2` receiving a backport). They are **not** a place to prepare a
+release and must never be used as the branch for a pull request. Base your work
+on `main`, or on the appropriate `release/x.y` branch for a hotfix to that line.
+
+### 📝 Pull request guidelines
+
+- 🧠 **Discuss major changes first**: for anything beyond a bug fix, contact the
+  team before investing time.
+- 🌳 **Base your PR on `main`** (or the appropriate `release/*` branch for hotfixes).
+- 🏷️ **PR titles follow [Conventional Commits](https://www.conventionalcommits.org/)**.
+  This repository squash-merges, so the PR title becomes the commit subject on
+  `main`. `lint-pr-title.yml` enforces this.
+- 🧹 **Match the existing coding style** — see [`docs/STYLE.md`](docs/STYLE.md).
+- ✅ **Sign your commits** (see DCO below).
+- 🧪 **Ensure checks pass**: `pytest tests/`, `ruff check .`, and pyright strict.
+
+---
+
+## 🧪 Local development
+
+```bash
+python -m venv venv
+source venv/bin/activate      # Windows: venv\Scripts\activate
+pip install -e .[test]
+
+pytest tests/                 # tests
+ruff check .                  # lint
+```
+
+If you changed the native extension surface, regenerate the type stub:
+
+```bash
+python scripts/generate_native_stub.py
+python scripts/generate_native_stub.py --check   # verify it is in sync
+```
+
+Note that flaky tests are treated as bugs in this project, not noise — see the
+"Zero tolerance for flakiness" section of [`CLAUDE.md`](CLAUDE.md) before
+re-running a failed test.
+
+---
+
+## ✅ Developer Certificate of Origin (DCO)
+
+By submitting a contribution, you certify the following:
+
+> "I certify that I have the right to submit this code under the open source
+> license indicated in this repository and that I am doing so in good faith."
+
+All commits must be signed off with a `Signed-off-by:` line. Commit with the
+`-s` flag to add it automatically:
+
+```bash
+git commit -s -m "fix: correct page tree index validation"
+```
+
+This appends a line like:
+
+```
+Signed-off-by: Your Name <you@example.com>
+```
+
+---
+
+## 🚀 Releases
+
+Releases are cut by maintainers via the `release.yml` workflow — tags are never
+created by hand. See [`RELEASE-GUIDE.md`](RELEASE-GUIDE.md) for the process and
+for how this package's version relates to the native library's.

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -1,0 +1,171 @@
+# 🧩 Vanilla.PDF Python Bindings — Release Guide
+
+How to cut stable and prerelease versions of the `vanillapdf` Python package.
+This mirrors the [native Vanilla.PDF release guide](https://github.com/vanillapdf/vanillapdf/blob/main/RELEASE-GUIDE.md);
+differences specific to Python packaging are called out below.
+
+---
+
+## 🔢 Versioning
+
+This package **mirrors the version of the native C++ library it wraps**, the same
+convention [vanillapdf.net](https://github.com/vanillapdf/vanillapdf.net) uses.
+Package `2.3.0` wraps native `2.3.0`, so the three repositories are readable
+together. The pinned native tag is `VANILLAPDF_GIT_TAG` in `CMakeLists.txt`.
+
+The version is therefore **not** a measure of how much of the native API the
+bindings cover — it identifies which library they wrap.
+
+### Binding-only releases
+
+A fix in the Python or extension layer with no corresponding native release gets
+a fourth component:
+
+```
+2.3.0    -> wraps native 2.3.0
+2.3.0.1  -> binding-only fix, still wraps native 2.3.0
+2.3.0.2  -> another binding-only fix
+2.3.1    -> wraps native 2.3.1
+```
+
+This is a normal PEP 440 release segment. It is not treated as a prerelease, it
+matches `~=2.3.0`, and it sorts below the next native patch.
+
+PEP 440 **post-releases (`2.3.0.post1`) are deliberately not used** — the spec
+reserves those for metadata corrections, explicitly stating that post-releases
+should not be used for bug fixes.
+
+### Prereleases
+
+Prerelease tags follow the native repository: `-alpha.N`, `-beta.N`, `-rc.N`.
+`v2.3.0-rc.2` normalizes to the PEP 440 version `2.3.0rc2`. Prereleases are never
+marked as the "latest" GitHub release, and `pip` will not install them without
+`--pre`.
+
+---
+
+## ✅ Branching strategy
+
+### `main`
+
+- Development happens here.
+- Prerelease tags (`alpha`, `beta`, `rc`) can be cut directly from here.
+
+### `release/x.y` (optional)
+
+- Created only when stabilizing a major/minor release, or to maintain an older
+  line after `main` has moved on.
+- 🔒 Not merged back into `main`; development continues from `main`.
+- **Never used as a branch for a pull request** — see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+```bash
+git checkout -b release/2.3 main
+```
+
+Fixes land on `main` first, then get cherry-picked into `release/x.y` if they
+apply. If the release branch is protected, the cherry-pick needs its own PR.
+
+---
+
+## 🏷️ Cutting a release
+
+Tags are **not** created manually with `git tag` / `git push`. The `release.yml`
+workflow owns tag creation end-to-end.
+
+**Before dispatching**, land a PR on `main` that:
+
+1. Sets `VANILLAPDF_GIT_TAG` in `CMakeLists.txt` to the native tag being wrapped.
+2. Adds a `## [x.y.z]` section to `CHANGELOG.md` for the version being released.
+   The `verify` job fails the run if this section is missing.
+
+Then:
+
+1. **Dry run.** Dispatch `release.yml` with the tag and `dry_run: true` (Actions
+   tab, or `gh workflow run release.yml -f tag=v2.3.0-rc.2 -f dry_run=true`).
+   This validates the tag, checks the CHANGELOG, and builds and tests the full
+   wheel matrix — publishing nothing and creating no tag.
+2. **Real run.** Re-dispatch with `dry_run: false`. Wheels are rebuilt, pushed to
+   **TestPyPI** as staging, and a GitHub release is created as a **draft** —
+   still without creating the tag.
+3. **Review.** The `production` environment gate pauses the workflow. Check the
+   staged wheels on TestPyPI, edit the draft release body in the UI, then approve.
+4. **Publish.** Approving publishes the draft, and *that* is what **creates the
+   tag**, at the commit the draft targets. The wheels then go to **PyPI**.
+
+Whether a tag counts as a prerelease is derived automatically from its suffix —
+see the `prepare` job in `release.yml`.
+
+### 🔁 Why the tag comes last
+
+If the tag were created first and the build then failed, the tag would have to be
+deleted and a fresh version chosen before retrying. Because the tag is created
+only after every wheel has built, installed, and passed its tests, a failed run
+is simply re-dispatched with the same tag. This matters more here than in a pure
+Python project: the matrix is five platforms × five Python versions, each doing a
+full C++ build via vcpkg.
+
+The same reasoning is why the draft release exists before the gate — it can be
+reviewed, and abandoned, without leaving anything permanent behind.
+
+---
+
+## 📦 How the version reaches the wheels
+
+`setuptools-scm` normally derives the version from a git tag, but the tag does
+not exist while the wheels are being built. `release.yml` therefore passes the
+version explicitly through `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VANILLAPDF`, set
+via `CIBW_ENVIRONMENT_*` so it reaches the build inside cibuildwheel's isolated
+environments and Linux containers.
+
+A guard step then checks every built wheel's filename against the expected
+version, so a wheel stamped with a guessed `.devN` version can never be
+published.
+
+Outside of releases (local installs, nightly, bleeding-edge CI) setuptools-scm
+still derives versions from git as usual — no environment variable is involved.
+
+---
+
+## 🧪 Workflow summary
+
+| Workflow             | Trigger                          | Publishes?                          |
+| -------------------- | -------------------------------- | ----------------------------------- |
+| `release.yml`        | `workflow_dispatch` (tag input)  | ✅ Yes, unless `dry_run: true`      |
+| `github-release.yml` | Called by `release.yml`          | Creates the **draft** release       |
+| `sanity-check.yml`   | Push / PR to `main`              | ❌ No                               |
+| `nightly-check.yml`  | Schedule                         | ❌ No                               |
+
+`github-release.yml` attaches the wheels, a signed provenance bundle
+(`*.intoto.jsonl`), and an SPDX SBOM to the release, and attests both.
+
+---
+
+## 🔧 Repository configuration
+
+These must exist for a release to complete:
+
+| Kind        | Name                    | Purpose                                                    |
+| ----------- | ----------------------- | ---------------------------------------------------------- |
+| Environment | `testpypi`              | Staging publish; holds `PYPI_REPOSITORY_URL` / `PYPI_PROJECT_URL` |
+| Environment | `pypi`                  | Production publish; same variables, pointing at PyPI        |
+| Environment | `production`            | **Human gate.** Configure required reviewers on it — this is what pauses the run before the tag is created |
+| Secret      | `BOT_TOKEN` (optional)  | Used to publish the draft so the tag can be created under tag protection rulesets; falls back to `GITHUB_TOKEN` |
+
+⚠️ **PyPI Trusted Publishing is bound to the repository, the workflow filename,
+and the environment name.** Renaming `release.yml`, `pypi`, or `testpypi`
+requires updating the publisher configuration on PyPI first, or publishing will
+fail with an OIDC error.
+
+---
+
+## 📌 Notes
+
+- **TestPyPI staging uses `skip-existing`**, so re-dispatching the same version
+  after a partial failure does not error on files that are already there. PyPI
+  itself is immutable: once a version is published it can never be replaced, so a
+  botched *publish* always needs a new version number.
+- The `0.0.0` release on TestPyPI dates from 2025-05-17, before `fetch-depth: 0`
+  was added to the release checkout. It predates this process and can be ignored.
+- Unlike the native repository, `release.yml` here is **not** validated on
+  pull requests. Building the full wheel matrix takes hours of CI, which is
+  disproportionate for a workflow edit — use a `dry_run: true` dispatch instead.


### PR DESCRIPTION
Ports the release process from the [native vanillapdf repository](https://github.com/vanillapdf/vanillapdf/blob/main/RELEASE-GUIDE.md) so all three wrappers share one model. Follow-up to #63.

## The change

`release.yml` now owns tag creation end-to-end. Tags are never created by hand.

```
dispatch (tag + dry_run) -> prepare -> verify -> build wheels
  dry_run:true  -> dry-run report, nothing published, no tag
  dry_run:false -> TestPyPI (staging) -> draft release -> production gate
                   -> publish draft (THIS creates the tag) -> PyPI
```

Approving the `production` gate publishes the draft, and that is what creates the tag, at the draft's target commit.

### Why tag-last

Tag-first is the mainstream setuptools-scm pattern, but it fits this repo badly. The matrix is five platforms × five Python versions, each doing a full C++ build via vcpkg — far more failure surface than a pure-Python package. With tag-first, any failure after the tag is pushed means deleting the tag and burning a version. Here a failed run is just re-dispatched with the same tag.

The draft release exists before the gate for the same reason: it can be reviewed, and abandoned, without leaving anything permanent behind.

## How the version reaches the wheels

setuptools-scm can't derive a version when no tag exists, so `release.yml` passes it explicitly via `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VANILLAPDF`, threaded through `CIBW_ENVIRONMENT_*` so it reaches cibuildwheel's isolated environments and Linux containers.

A guard step then checks every wheel filename against the expected version, so a wheel stamped with a guessed `.devN` can never be published — that is exactly how `0.0.0` ended up on TestPyPI in 2025.

Outside releases (local installs, nightly, bleeding-edge) setuptools-scm is untouched and still derives from git.

One caveat, stated plainly: the setuptools-scm docs present `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_*` as a **containerized-build workaround**, not as a release-ordering mechanism. Using it this way is slightly off-label. It is stable public API and low-risk, but it is not what the docs describe.

## Also included

- **`verify` job** — blocks a tag that already exists (publishing a draft over an existing tag binds the release to an `untagged-*` placeholder) and requires a matching `## [x.y.z]` CHANGELOG section.
- **`github-release.yml`** — creates the draft, attaches wheels, a signed provenance bundle (`*.intoto.jsonl`), and an SPDX SBOM, and attests both.
- **`lint-pr-title.yml`** — this repo squash-merges, so the PR title becomes the commit subject; enforces Conventional Commits.
- **`CONTRIBUTING.md`** — documents `feature/…` and `fix/…` branch naming, DCO sign-off, and that `release/x.y` is reserved for maintenance lines and is never the branch for a PR.
- **`RELEASE-GUIDE.md`** — the full process, plus the versioning rules (mirrored native version; `2.3.0.1` for binding-only fixes, not `.post1`).

## Verification

Workflow YAML parses, and the tag-parsing logic was exercised against a scratch repo with existing tags:

| tag | version | prerelease | is_latest |
|---|---|---|---|
| `v2.3.0-rc.2` | `2.3.0rc2` | true | false |
| `v2.3.0` | `2.3.0` | false | true |
| `v2.3.0.1` | `2.3.0.1` | false | true |
| `v2.2.5` | `2.2.5` | false | **false** |
| `vBAD` | rejected | — | — |
| `2.3.0` (no `v`) | rejected | — | — |

`v2.2.5` reporting `is_latest=false` is the important one: a maintenance release on an older line cannot clobber "latest".

Not verified: an end-to-end run. The gate, the draft-publish-creates-tag behavior, and the OIDC publishes can only really be exercised by a `dry_run: true` dispatch after merge — that is the intended next step, before any real release.

## ⚠️ Required repository configuration

The `production` environment **does not exist yet** and must be created with required reviewers — it is the human gate, and without it the workflow will not pause before creating the tag.

`BOT_TOKEN` is optional; it falls back to `GITHUB_TOKEN`, which is enough unless tag protection rulesets are in play.

PyPI Trusted Publishing is bound to (repository, workflow filename, environment name). This PR deliberately keeps the `release.yml` filename and the `pypi` / `testpypi` environment names so existing publisher config keeps working.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>